### PR TITLE
Fix: single_nat_gateway with enable=false attribute

### DIFF
--- a/_example/complete/example.tf
+++ b/_example/complete/example.tf
@@ -1,20 +1,24 @@
 provider "aws" {
-  region = "eu-west-1"
+  region = local.region
 }
 
 locals {
   name        = "app"
   environment = "test"
+  region      = "eu-west-1"
 }
 
 ##----------------------------------------------------------------------------- 
 ## Vpc Module call.    
 ##-----------------------------------------------------------------------------
 module "vpc" {
-  source                              = "clouddrove/vpc/aws"
-  version                             = "2.0.0"
-  name                                = local.name
-  environment                         = local.environment
+  source  = "clouddrove/vpc/aws"
+  version = "2.0.0"
+
+  enable      = true
+  name        = local.name
+  environment = local.environment
+
   cidr_block                          = "10.0.0.0/16"
   enable_flow_log                     = true # Flow logs will be stored in cloudwatch log group. Variables passed in default.
   create_flow_log_cloudwatch_iam_role = true
@@ -31,11 +35,15 @@ module "vpc" {
 #tfsec:ignore:aws-ec2-no-excessive-port-access 
 #tfsec:ignore:aws-ec2-no-public-ingress-acl
 module "subnets" {
-  source                                         = "./../../"
-  name                                           = local.name
-  environment                                    = local.environment
+  source = "./../../"
+
+  enable      = true
+  name        = local.name
+  environment = local.environment
+
   nat_gateway_enabled                            = true
-  availability_zones                             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  single_nat_gateway                             = true
+  availability_zones                             = ["${local.region}a", "${local.region}b", "${local.region}c"]
   vpc_id                                         = module.vpc.vpc_id
   type                                           = "public-private"
   igw_id                                         = module.vpc.igw_id

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
 locals {
   public_count      = var.enable == true && (var.type == "public" || var.type == "public-private") ? length(var.availability_zones) : 0
   private_count     = var.enable == true && (var.type == "private" || var.type == "public-private") ? length(var.availability_zones) : 0
-  nat_gateway_count = var.single_nat_gateway ? 1 : (var.enable == true && (var.type == "private" || var.type == "public-private") && var.nat_gateway_enabled == true ? length(var.availability_zones) : 0)
+  nat_gateway_count = var.enable == true && var.single_nat_gateway ? 1 : (var.enable == true && (var.type == "private" || var.type == "public-private") && var.nat_gateway_enabled == true ? length(var.availability_zones) : 0)
 }
 ##----------------------------------------------------------------------------- 
 ## Labels module called that will be used for naming and tags.   


### PR DESCRIPTION
## what
- Updated `single_nat_gateway` creation condition when `enable = false` is used for below error -
>│ Error: Error in function call
│ 
│   on ../../main.tf line 319, in resource "aws_nat_gateway" "private":
│  319:   subnet_id     = length(aws_subnet.public) > 0 ? element(aws_subnet.public[*].id, count.index) : element(var.public_subnet_ids, count.index)
│     ├────────────────
│     │ while calling element(list, index)
│     │ count.index is 0
│ 
│ Call to function "element" failed: cannot use element function with an empty list.
