### PR TITLE
Fix: 🐛  Remove whole tags from public and private subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,6 @@ resource "aws_subnet" "public" {
   lifecycle {
     # Ignore tags added by kubernetes
     ignore_changes = [
-      tags,
       tags["kubernetes.io"],
       tags["SubnetType"],
     ]
@@ -216,7 +215,6 @@ resource "aws_subnet" "private" {
   lifecycle {
     # Ignore tags added by kubernetes
     ignore_changes = [
-      tags,
       tags["kubernetes.io"],
       tags["SubnetType"],
     ]


### PR DESCRIPTION
## what
* Removed tags from ignore changes in public and private subnets.

## why
* was not able to updated the current tags after deployment due to tags added in the lifecycle ignore changes.
